### PR TITLE
Update textools.nsi

### DIFF
--- a/textools.nsi
+++ b/textools.nsi
@@ -49,9 +49,6 @@ OutFile "Install_TexTools.exe"
 Name "FFXIV TexTools"
 
  
-# For removing Start Menu shortcut in Windows 7
-RequestExecutionLevel user
- 
 # start default section
 Section "Install"
 


### PR DESCRIPTION
remove a technically unpopulated part of the script which is overriding the topmost setexecutionlevel causing installation to fail to request elevation on start and jump straight to the requires elevation warning dialogue.